### PR TITLE
Test against ^2.4 vs 2.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Create DKAN site with frontend; run tests
           command: |
-            dktl init --dkan=2.x-dev
+            dktl init
             dktl make
             dktl install
             dktl install:sample


### PR DESCRIPTION
Let's put a compatibility message in the release notes: 

`DKAN compatibility: 2.4.1`

or should master always test against DKAN 2.x, and only list compatibility on past releases...
the current tests work against 2.x or 2.4.1 once it is released, they fail on 2.4.0