### PR TITLE
Add a config object for dkan endpoints

### DIFF
--- a/src/config/endpoints.js
+++ b/src/config/endpoints.js
@@ -1,0 +1,51 @@
+export const dkanEndpoints = {
+  // Put site URL here or process.env.REACT_APP_ROOT_URL
+  siteUrl: process.env.REACT_APP_ROOT_URL,
+  apiPath: '/api/1',
+  get api() {
+    return `${this.siteUrl}${this.apiPath}`;
+  },
+  get datastore() {
+    // Requires a POST request with the request data
+    return `${this.api}/datastore/query`;
+  },
+  get search() {
+    // example: ?${apiParams}
+    return `${this.api}/search`;
+  },
+  get facets() {
+    // You can append Search API parameters to the facets endpoint.
+    // The endpoint also takes a special &facets= where only listed facets will be returned.
+    // example: `?${apiParams}&facets=${facet}`
+    return `${this.api}/facets`;
+  },
+  metastoreSchemas: function(schema = '') {
+    if (!schema) {
+      return `${this.api}/metastore/schemas`;
+    }
+    return `${this.api}/metastore/schemas/${schema}`;
+  },
+  metastoreItems: function(schema, id, showReferenceIds = true) {
+    if (!schema) {
+      throw 'Must include schema';
+    }
+    if (!id && !showReferenceIds) {
+      return `${this.api}/metastore/schemas/${schema}/items`;
+    }
+    if (!id) {
+      return `${this.api}/metastore/schemas/${schema}/items?show-reference-ids`;
+    }
+    if (!showReferenceIds) {
+      return `${this.api}/metastore/schemas/${schema}/items/${id}`;
+    }
+    return `${this.api}/metastore/schemas/${schema}/items/${id}?show-reference-ids`;
+  },
+  get sql() {
+    // This needs a SQL query added to the url as a search param
+    // example: ?query=[]
+    return `${this.api}/datastore/sql`;
+  }
+}
+
+
+

--- a/src/config/endpoints.test.js
+++ b/src/config/endpoints.test.js
@@ -1,0 +1,30 @@
+import { dkanEndpoints } from './endpoints';
+
+describe('API Endpoint Config Object', () => {
+  test('has correct base urls', () => {
+    expect(dkanEndpoints.siteUrl).toBe('http://dkan.org');
+    expect(dkanEndpoints.apiPath).toBe('/api/1');
+    expect(dkanEndpoints.api).toBe('http://dkan.org/api/1');
+  });
+  
+  test('has correct search urls', () => {
+    expect(dkanEndpoints.search).toBe('http://dkan.org/api/1/search');
+    expect(dkanEndpoints.search).toBe('http://dkan.org/api/1/search');
+  });
+  
+  test('has correct datastore urls', () => {
+    expect(dkanEndpoints.datastore).toBe('http://dkan.org/api/1/datastore/query');
+    expect(dkanEndpoints.sql).toBe('http://dkan.org/api/1/datastore/sql');
+  });
+  
+  test('has correct metastore urls', () => {
+    expect(dkanEndpoints.metastoreSchemas()).toBe('http://dkan.org/api/1/metastore/schemas');
+    expect(dkanEndpoints.metastoreSchemas('datasets')).toBe('http://dkan.org/api/1/metastore/schemas/datasets');
+
+    expect(() => dkanEndpoints.metastoreItems()).toThrow('Must include schema');
+    expect(dkanEndpoints.metastoreItems('datasets')).toBe('http://dkan.org/api/1/metastore/schemas/datasets/items?show-reference-ids');
+    expect(dkanEndpoints.metastoreItems('datasets', '1234')).toBe('http://dkan.org/api/1/metastore/schemas/datasets/items/1234?show-reference-ids');
+    expect(dkanEndpoints.metastoreItems('datasets', '1234', false)).toBe('http://dkan.org/api/1/metastore/schemas/datasets/items/1234');
+    expect(dkanEndpoints.metastoreItems('datasets', null, false)).toBe('http://dkan.org/api/1/metastore/schemas/datasets/items');
+  });
+})


### PR DESCRIPTION
This could be an option to remove hardcoded paths from the services. Only 2 are functions but the rest can used like `dkanEndpoints.datastore`.