### PR TITLE
Dynamic publishers

### DIFF
--- a/src/templates/publishers/index.jsx
+++ b/src/templates/publishers/index.jsx
@@ -1,10 +1,31 @@
 import React from 'react';
+import axios from 'axios';
 import { PublisherList } from "@civicactions/data-catalog-components";
 import config from "../../assets/config";
 import Layout from '../../components/Layout';
-import orgs from "../../assets/publishers";
 
 const Publishers = () => {
+  const { t } = useTranslation('publishers');
+  const [orgs, setOrgs] = React.useState(null);
+  const [publishers, setPublishers] = React.useState([])
+
+  React.useEffect(() => {
+    async function getOrgs() {
+      const { data } = await axios.get(`${process.env.REACT_APP_ROOT_URL}/metastore/schemas/publisher/items`)
+      setOrgs(data);
+    }
+    if (orgs === null) {
+      getOrgs();
+    }
+    if (orgs) {
+      const items = [];
+      orgs.forEach(element => {
+        items.push(element.data);
+      });
+      setPublishers(items);
+    }
+  }, [orgs])
+
   return (
     <Layout title="Dataset Publishers">
     <div className={`dc-page ${config.container}`}>
@@ -20,7 +41,7 @@ const Publishers = () => {
           publishing data to the same site.
         </p>
 
-        <PublisherList items = {orgs} />
+        <PublisherList items = {publishers} />
 
       </div>
     </div>


### PR DESCRIPTION
Current publishers page use the file assets/publishers.json to display the publishers, so when a new publisher is added in the website it is still not displayed in this page. In this PR I'm changing it so that we use the API at `/metastore/schemas/theme/items` to show always the most updated list.