### PR TITLE
Add item to manual setup readme section for DKAN JS Frontend module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you have a backend already running and just need the frontend:
 1) Run the server: ``npm start`` or ``yarn start``
    1) Your site is now running at ``http://localhost:3000``
 1) Build the public files ``npm run build``
+1) To complete the setup like the auto setup, setup the DKAN JS Frontend module that comes with the DKAN core installation. Steps can be found here: [DKAN JS Frontend Module](https://github.com/GetDKAN/dkan/tree/2.x/modules/dkan_js_frontend).
 
 ## Set up of an independent front-end (with no backend)
 


### PR DESCRIPTION
There was a missing step in the manual DKAN setup on how to connect the newly built React app to the DKAN Drupal site when doing a manual installation. This PR adds a new point with a link to the setup steps in the module's Readme. 