### PR TITLE
Add /home and * routes

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { Navigate, createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './config/queryClient';
 import '@civicactions/data-catalog-components/dist/index.css';
@@ -19,6 +19,10 @@ const router = createBrowserRouter([
   {
     path: "/",
     element: <Home />
+  },
+  {
+    path: "/home",
+    element: <Navigate replace to="/" />
   },
   {
     path: "/about",
@@ -43,6 +47,10 @@ const router = createBrowserRouter([
   {
     path: "/dataset/:id/api",
     element: <ApiDocsSpecific />
+  },
+  {
+    path: '*',
+    element: <NotFound />,
   },
 ]);
 


### PR DESCRIPTION
Fixes #142

/home will redirect to /
Anything not in the createBrowserRouter array, will redirect to NotFound (using * wildcardpath)

The addition of the wildcard will fix the issues raised in https://github.com/GetDKAN/dkan/issues/4121 as it was showing the error boundary default messaging on any page that wasn't part of the router. 