### PR TITLE
wrap notfound template with Layout component

### DIFF
--- a/src/templates/not_found/index.jsx
+++ b/src/templates/not_found/index.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import Layout from '../../components/Layout';
 
 const NotFound = () => {
   return (
-    <h1>Page not found.</h1>
+    <Layout title="Dataset Publishers">
+      <div class="dc-page container">
+        <h1>Page not found.</h1>
+        <p>We're sorry, we can't find the page you're looking for.</p>
+      </div>
+    </Layout>
   );
 }
 

--- a/src/templates/not_found/index.jsx
+++ b/src/templates/not_found/index.jsx
@@ -3,7 +3,7 @@ import Layout from '../../components/Layout';
 
 const NotFound = () => {
   return (
-    <Layout title="Dataset Publishers">
+    <Layout title="Page not found">
       <div class="dc-page container">
         <h1>Page not found.</h1>
         <p>We're sorry, we can't find the page you're looking for.</p>


### PR DESCRIPTION
fixes #143

The NotFound template just had an H1 with no Layout component wrapping it. This meant the header and footer wouldn't load on the page. 